### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: Deploy
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Daisuke106/hide-and-seek-earth/security/code-scanning/11](https://github.com/Daisuke106/hide-and-seek-earth/security/code-scanning/11)

To correct this issue, add an explicit `permissions` block to the workflow YAML at the root level, immediately below the `name:` declaration (and optionally as needed on specific jobs). The block should follow the principle of least privilege—granting only the permissions required for each job. For most deployment and notification jobs that don't interact with repository contents or PRs, `contents: read` is the minimal safe default. If any jobs require additional permissions (e.g., to write deployment statuses, open PRs, etc.), you can grant the required `write` permissions for those specific scopes at the job level. 

In this code snippet, none of the jobs appear to need repository write permission, as they only perform deployment and notification via shell scripts. Therefore, adding `permissions: contents: read` at the workflow root is recommended, applying to all jobs unless overridden. 

Edit `.github/workflows/deploy.yml` and insert:

```yaml
permissions:
  contents: read
```

as line 2 (after `name: Deploy`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
