### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,8 @@ jobs:
     name: Integration Tests
     runs-on: ubuntu-latest
     needs: [backend-tests, frontend-tests]
+    permissions:
+      contents: read
     
     services:
       mysql:


### PR DESCRIPTION
Potential fix for [https://github.com/Daisuke106/hide-and-seek-earth/security/code-scanning/10](https://github.com/Daisuke106/hide-and-seek-earth/security/code-scanning/10)

The optimal solution is to specify a `permissions` block for the `integration-tests` job (or at the top workflow level, if desired) that grants the lowest privilege necessary. Based on the steps in the `integration-tests` job—checking out code, installing dependencies, running tests—only read access to repository contents is required. This is done by adding a `permissions:` block with `contents: read` under the `integration-tests:` job entry (i.e., under line 175 in the YAML). This restricts the `GITHUB_TOKEN` to only be able to read repository contents for this job, in accordance with the principle of least privilege.

No further changes or new dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
