### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,8 @@ jobs:
   # Code Quality Checks
   code-quality:
     name: Code Quality
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/Daisuke106/hide-and-seek-earth/security/code-scanning/9](https://github.com/Daisuke106/hide-and-seek-earth/security/code-scanning/9)

The correct fix is to add a `permissions` block to the `code-quality` job to restrict the `GITHUB_TOKEN` to only what is needed. In this case, the least privilege required is `contents: read` (the minimum necessary for code checkout and access), as the steps don't require any write access. Specifically, add:

```yaml
permissions:
  contents: read
```

as the first key (before `runs-on`) under the `code-quality` job, after its `name` field, at line 146.

No imports, variable, or additional definitions are needed, just a direct YAML edit.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
