### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-simple.yml
+++ b/.github/workflows/ci-simple.yml
@@ -1,4 +1,6 @@
 name: CI Pipeline - Simplified
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Daisuke106/hide-and-seek-earth/security/code-scanning/7](https://github.com/Daisuke106/hide-and-seek-earth/security/code-scanning/7)

The recommended fix is to add a `permissions:` block to restrict the GITHUB_TOKEN for the workflow or for the security-basic job. Since none of the jobs (backend-tests, frontend-tests, security-basic) use write operations (e.g., do not publish artifacts, create PRs, push code, etc.), a top-level `permissions:` block restricting to `contents: read` is sufficient and the simplest solution, but if more granularity is needed in the future it can be set per-job. This block should be added right after the `name:` field at the root of the YAML, so that all jobs inherit these minimal permissions unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
