### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,8 @@ jobs:
   # React Frontend Tests
   frontend-tests:
     name: Frontend Tests
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/Daisuke106/hide-and-seek-earth/security/code-scanning/5](https://github.com/Daisuke106/hide-and-seek-earth/security/code-scanning/5)

To fix the problem, we should add an explicit `permissions` block to the `frontend-tests` job (lines 77 onwards) with the minimal necessary permissions. For this job, since its steps perform only read operations and uploads, `contents: read` is the usually recommended base permission. You should insert:

```yaml
permissions:
  contents: read
```

as the first key inside the job definition, directly after `name:` (or, for aesthetics/clarity, after `runs-on:` if you like). No other permission is necessary unless you later add steps that require write access to other parts of the repository, such as issues or pull requests.

**File/region to change:**  
Edit the `.github/workflows/ci.yml` file, modifying the `frontend-tests` job (between lines 77 and 79/80), adding the `permissions:` block.

_No additional imports, method or variable definitions are required, as this is a YAML configuration update for GitHub Actions._

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
