### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
   # Laravel Backend Tests
   backend-tests:
     name: Backend Tests (PHP ${{ matrix.php }})
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/Daisuke106/hide-and-seek-earth/security/code-scanning/1](https://github.com/Daisuke106/hide-and-seek-earth/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block with the least needed privileges to the `backend-tests` job. The minimum required for code checkout and Codecov upload is typically `contents: read`. This change should be made under the `backend-tests:` job in `.github/workflows/ci.yml` (specifically after line 16, before `runs-on`), just like it is done for other jobs such as `frontend-tests` and `code-quality`. No package install or external dependencies are needed beyond editing this YAML.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
